### PR TITLE
Refactor controllers with namespaces and service loader

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Routing\RouteCollection;
+use Config\Services;
+
+$routes = Services::routes();
+
+$routes->get('/', 'Welcome::index');
+$routes->get('admin/login', 'Admin::login');
+$routes->post('api/login', 'Api::login');

--- a/application/controllers/Admin.php
+++ b/application/controllers/Admin.php
@@ -1,30 +1,25 @@
 <?php
-defined('BASEPATH') or exit('No direct script access allowed');
 
-class Admin extends CI_Controller
+namespace App\Controllers;
+
+use CodeIgniter\Controller;
+
+class Admin extends Controller
 {
+    protected $db;
+    protected $admin_model;
+    protected $form_validation;
 
     public function __construct()
     {
-        parent::__construct();
-        $this
-            ->load
-            ->database();
-        $this
-            ->load
-            ->model('admin_model');
-        $this
-            ->load
-            ->library('form_validation');
-        $this
-            ->load
-            ->helper('utility');
-        $this
-            ->load
-            ->helper('url');
+        $this->db = \Config\Database::connect();
+        $this->admin_model = model('admin_model');
+        $this->form_validation = \Config\Services::validation();
+        helper('utility');
+        helper('url');
         date_default_timezone_set("Asia/Dhaka");
         //$today = date('Y-m-d');
-        
+
     }
 
     public function daily_collection()

--- a/application/controllers/Admin_old.php
+++ b/application/controllers/Admin_old.php
@@ -1,30 +1,25 @@
 <?php
-defined('BASEPATH') or exit('No direct script access allowed');
 
-class Admin extends CI_Controller
+namespace App\Controllers;
+
+use CodeIgniter\Controller;
+
+class Admin_old extends Controller
 {
+    protected $db;
+    protected $admin_model;
+    protected $form_validation;
 
     public function __construct()
     {
-        parent::__construct();
-        $this
-            ->load
-            ->database();
-        $this
-            ->load
-            ->model('admin_model');
-        $this
-            ->load
-            ->library('form_validation');
-        $this
-            ->load
-            ->helper('utility');
-        $this
-            ->load
-            ->helper('url');
+        $this->db = \Config\Database::connect();
+        $this->admin_model = model('admin_model');
+        $this->form_validation = \Config\Services::validation();
+        helper('utility');
+        helper('url');
         date_default_timezone_set("Asia/Dhaka");
         //$today = date('Y-m-d');
-        
+
     }
 
     public function daily_collection()

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -1,10 +1,16 @@
 <?php
-defined('BASEPATH') OR exit('No direct script access allowed');
-class Api extends CI_Controller {
+
+namespace App\Controllers;
+
+use CodeIgniter\Controller;
+
+class Api extends Controller {
+    protected $Admin_model;
+    protected $validation;
+
     public function __construct(){
-        parent::__construct();
-        $this->load->model('Admin_model'); // Load your admin model here
-        $this->load->library('form_validation');
+        $this->Admin_model = model('Admin_model'); // Load your admin model here
+        $this->validation = \Config\Services::validation();
         header('Content-Type: application/json');
     }
     public function login(){
@@ -59,13 +65,15 @@ class Api extends CI_Controller {
         }
 
         // Set form validation rules
-        $this->form_validation->set_rules('name', 'Name', 'required');
-        $this->form_validation->set_rules('mobile', 'Mobile', 'required');
-        $this->form_validation->set_rules('monthly_amount', 'Monthly Saving Amount', 'required|numeric');
-        
+        $this->validation->setRules([
+            'name' => 'required',
+            'mobile' => 'required',
+            'monthly_amount' => 'required|numeric'
+        ]);
+
         // Other validation rules for each field
 
-        if ($this->form_validation->run() == FALSE) {
+        if ($this->validation->run() == FALSE) {
             // Validation failed
             $response = array('status' => 'error', 'message' => validation_errors());
             echo json_encode($response);

--- a/application/controllers/Welcome.php
+++ b/application/controllers/Welcome.php
@@ -1,7 +1,10 @@
 <?php
-defined('BASEPATH') OR exit('No direct script access allowed');
 
-class Welcome extends CI_Controller {
+namespace App\Controllers;
+
+use CodeIgniter\Controller;
+
+class Welcome extends Controller {
 
 	/**
 	 * Index Page for this controller.


### PR DESCRIPTION
## Summary
- Add `App\Controllers` namespace and switch to service-based resource loading for all controllers
- Introduce route definitions for `Welcome::index`, `Admin::login`, and `Api::login`

## Testing
- `php -l application/controllers/Admin.php`
- `php -l application/controllers/Admin_old.php`
- `php -l application/controllers/Api.php`
- `php -l application/controllers/Welcome.php`
- `php -l app/Config/Routes.php`


------
https://chatgpt.com/codex/tasks/task_b_689d974bd26483339c99487ad541b7ff